### PR TITLE
Fix Polish translation ("export instance")

### DIFF
--- a/pl.po
+++ b/pl.po
@@ -2411,7 +2411,7 @@ msgstr "Zmień specyficzne ustawienia instancji"
 #, fuzzy
 msgctxt "MainWindow|"
 msgid "Export Instance"
-msgstr "Edytuj instancję"
+msgstr "Eksportuj instancję"
 
 #: src/application/MainWindow.cpp:394
 #, qt-format


### PR DESCRIPTION
Fix simple mistake ("edit" → "export") in Polish translation.