### PR TITLE
Fix german translation of "Fabric"

### DIFF
--- a/de.po
+++ b/de.po
@@ -4807,16 +4807,14 @@ msgid "Add to Minecraft.jar"
 msgstr "Zur Minecraft.jar hinzufügen"
 
 #: src/application/pages/instance/VersionPage.ui:170
-#, fuzzy
 msgctxt "VersionPage|"
 msgid "Install Fabric"
-msgstr "Forge installieren"
+msgstr "Fabric installieren"
 
 #: src/application/pages/instance/VersionPage.ui:173
-#, fuzzy
 msgctxt "VersionPage|"
 msgid "Install the Fabric Loader package."
-msgstr "LiteLoader installieren."
+msgstr "Den Fabric Mod Loader installieren."
 
 #: src/application/pages/instance/VersionPage.ui:202
 msgctxt "VersionPage|"
@@ -5167,7 +5165,6 @@ msgid "Copy"
 msgstr "Kopieren"
 
 #: src/application/pages/instance/WorldListPage.ui:107
-#, fuzzy
 msgctxt "WorldListPage|"
 msgid "Remove"
 msgstr "Entfernen"
@@ -5179,7 +5176,6 @@ msgid "MCEdit"
 msgstr "Bearbeiten"
 
 #: src/application/pages/instance/WorldListPage.ui:127
-#, fuzzy
 msgctxt "WorldListPage|"
 msgid "View Folder"
 msgstr "&Ordner öffnen"


### PR DESCRIPTION
It was translated as Forge, which is clearly wrong