### PR TITLE
Update nl.po

### DIFF
--- a/nl.po
+++ b/nl.po
@@ -1806,13 +1806,13 @@ msgstr "Proces is afgesloten met code %1."
 #: src/api/logic/LoggedProcess.cpp:75
 msgctxt "LoggedProcess|"
 msgid "Process crashed."
-msgstr "Process gecrashed."
+msgstr "Process gecrasht."
 
 #: src/api/logic/LoggedProcess.cpp:77
 #, qt-format
 msgctxt "LoggedProcess|"
 msgid "Process crashed with exitcode %1."
-msgstr "Proces is gecrashed met code %1."
+msgstr "Proces is gecrasht met code %1."
 
 #. Message displayed after the instance exits due to kill request
 #: src/api/logic/LoggedProcess.cpp:84
@@ -2294,7 +2294,7 @@ msgstr ", gespeeld gedurende %1"
 #: src/api/logic/minecraft/MinecraftInstance.cpp:760
 msgctxt "MinecraftInstance|"
 msgid ", has crashed."
-msgstr ", is gecrashed."
+msgstr ", is gecrasht."
 
 #: src/application/pages/global/MinecraftPage.ui:48
 msgctxt "MinecraftPage|"
@@ -2626,7 +2626,7 @@ msgstr "Console automatisch sluiten als het spel wordt gestopt?"
 #: src/application/pages/global/MultiMCPage.ui:374
 msgctxt "MultiMCPage|"
 msgid "Show console when the game crashes?"
-msgstr "Console weergeven wanneer het spel crashed?"
+msgstr "Console weergeven wanneer het spel crasht?"
 
 #: src/application/pages/global/MultiMCPage.ui:384
 msgctxt "MultiMCPage|"


### PR DESCRIPTION
Fixed spelling of tenses of borrowed verb "crash" in Dutch translation